### PR TITLE
update phraseapp to version 1.1.13

### DIFF
--- a/Formula/phraseapp.rb
+++ b/Formula/phraseapp.rb
@@ -6,8 +6,8 @@ class Phraseapp < Formula
   desc "PhraseApp CLI Tool - API client binary"
   homepage "https://phraseapp.com/cli"
 
-  version "1.1.12"
-  sha256 "c83c5745cbadea2eada2efb901ad8998a939a2e3c29006ca30da8220a3c0a245"
+  version "1.1.13"
+  sha256 "9403312ec9ff7a723f1f3f9cfaa60050b1e57778b7725e3a8d966d82632838af"
 
   url "https://github.com/phrase/phraseapp-client/releases/download/#{version}/phraseapp_macosx_amd64.tar.gz"
 


### PR DESCRIPTION
This pull request updates phraseapp cli to version 1.1.13

What happened in this pull request

- Update version to 1.1.13
- Download phraseapp_macosx_amd64.tar.gz and compute sha256 via `shasum -a 256 phraseapp_macosx_amd64.tar.gz`