### PR TITLE
Revert "phrase-cli: renamed from phrase"

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,3 +1,0 @@
-{
-    "phrase": "phrase-cli"
-}


### PR DESCRIPTION
The rename does seem to work in combination with the tap migration and the new formula cannot be found. Let's revert the rename for now and we need to find a different solution